### PR TITLE
Ignore mercurial warnings printed to stderr as long as the exitstatus is 0

### DIFF
--- a/lib/mercurial-ruby/command.rb
+++ b/lib/mercurial-ruby/command.rb
@@ -47,8 +47,8 @@ module Mercurial
     def execution_proc
       Proc.new do
         debug(command)
-        result, error = '', ''        
-        Open3.popen3(command) do |_, stdout, stderr|
+        result, error, status = '', '', nil
+        Open3.popen3(command) do |_, stdout, stderr, wait_thr|
           Timeout.timeout(timeout) do
             while tmp = stdout.read(102400)
               result += tmp
@@ -58,8 +58,9 @@ module Mercurial
           while tmp = stderr.read(1024)
             error += tmp
           end
+          status = wait_thr.value
         end
-        raise_error_if_needed(error)
+        raise_error_if_needed(error) if status.nil? || status.exitstatus != 0
         result
       end
     end

--- a/lib/mercurial-ruby/command.rb
+++ b/lib/mercurial-ruby/command.rb
@@ -60,13 +60,13 @@ module Mercurial
           end
           status = wait_thr.value
         end
-        raise_error_if_needed(error) if status.nil? || status.exitstatus != 0
+        raise_error_if_needed(error, status)
         result
       end
     end
     
-    def raise_error_if_needed(error)
-      if error && error != ''
+    def raise_error_if_needed(error, status = nil)
+      if (status.nil? || status.exitstatus != 0) && error && error != ''
         raise CommandError, error
       end
     end

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -16,6 +16,18 @@ describe Mercurial::Command do
       Mercurial::Command.new("cd #{ @repository.path } && hg shikaka").execute
     }.must_raise Mercurial::CommandError
   end
+
+  it "should not translate exit status of zero with shell errors to ruby exceptions" do
+    lambda{
+      Mercurial::Command.new("echo stderr >&2 && echo stdout && exit 0").execute
+    }.must_equal "stdout"
+  end
+
+  it "should translate exit status of non-zero with shell errors to ruby exceptions" do
+    lambda{
+      Mercurial::Command.new("echo stderr >&2 && echo stdout && exit 1").execute
+    }.must_raise Mercurial::CommandError
+  end
   
   it "should execute commands with timeout" do
     Mercurial.configuration.stubs(:shell_timeout).returns(1)


### PR DESCRIPTION
An error should only be raised if the process exited irregularly (non-zero).

Here's the example case I ran into:

``` bash
$ hg id https://bitbucket.org/django/django
warning: bitbucket.org certificate with fingerprint 24:9c:45:8b:9c:aa:ba:55:4e:01:6d:58:ff:e4:28:7d:2a:14:ae:3b not verified (check hostfingerprints or web.cacerts config setting)
warning: bitbucket.org certificate with fingerprint 24:9c:45:8b:9c:aa:ba:55:4e:01:6d:58:ff:e4:28:7d:2a:14:ae:3b not verified (check hostfingerprints or web.cacerts config setting)
warning: bitbucket.org certificate with fingerprint 24:9c:45:8b:9c:aa:ba:55:4e:01:6d:58:ff:e4:28:7d:2a:14:ae:3b not verified (check hostfingerprints or web.cacerts config setting)
warning: bitbucket.org certificate with fingerprint 24:9c:45:8b:9c:aa:ba:55:4e:01:6d:58:ff:e4:28:7d:2a:14:ae:3b not verified (check hostfingerprints or web.cacerts config setting)
f96430a396e1
$ echo $?
0
```

Technically this command was successful, but when running it from the gem...

``` ruby
>> Mercurial::Shell.run(["id ?", "https://bitbucket.org/django/django"], append_hg: true)
Mercurial::CommandError: warning: bitbucket.org certificate with fingerprint 24:9c:45:8b:9c:aa:ba:55:4e:01:6d:58:ff:e4:28:7d:2a:14:ae:3b not verified (check hostfingerprints or web.cacerts config setting)
warning: bitbucket.org certificate with fingerprint 24:9c:45:8b:9c:aa:ba:55:4e:01:6d:58:ff:e4:28:7d:2a:14:ae:3b not verified (check hostfingerprints or web.cacerts config setting)
warning: bitbucket.org certificate with fingerprint 24:9c:45:8b:9c:aa:ba:55:4e:01:6d:58:ff:e4:28:7d:2a:14:ae:3b not verified (check hostfingerprints or web.cacerts config setting)
warning: bitbucket.org certificate with fingerprint 24:9c:45:8b:9c:aa:ba:55:4e:01:6d:58:ff:e4:28:7d:2a:14:ae:3b not verified (check hostfingerprints or web.cacerts config setting)
from ~/.rvm/gems/ruby-1.9.3-p125/gems/mercurial-ruby-0.6.1/lib/mercurial-ruby/command.rb:69:in `raise_error_if_needed'
```

This pull request allows the previous command to run as expected...

``` ruby
>> Mercurial::Shell.run(["id ?", "https://bitbucket.org/django/django"], append_hg: true)
=> "f96430a396e1\n"
```

...while still throwing a ruby exception if the exitstatus is not 0

``` ruby
>> Mercurial::Shell.run(["id ?", "https://bitbucket.org/django/i-dont-exist"], append_hg: true)
Mercurial::CommandError: warning: bitbucket.org certificate with fingerprint 24:9c:45:8b:9c:aa:ba:55:4e:01:6d:58:ff:e4:28:7d:2a:14:ae:3b not verified (check hostfingerprints or web.cacerts config setting)
abort: HTTP Error 404: NOT FOUND
from ~/.rvm/gems/ruby-1.9.3-p125@pagoda/bundler/gems/mercurial-ruby-9f0166b30d06/lib/mercurial-ruby/command.rb:70:in `raise_error_if_needed'
```
