### PR TITLE
Fixes for using mercurial-ruby on Windows

### DIFF
--- a/lib/mercurial-ruby/shell.rb
+++ b/lib/mercurial-ruby/shell.rb
@@ -103,7 +103,11 @@ module Mercurial
     def self.interpolate_arguments(cmd_with_args)
       cmd_with_args.shift.tap do |cmd|
         cmd.gsub!(/\?/) do
-          cmd_with_args.shift.to_s.enclose_in_single_quotes
+          if ENV['OS'] == 'Windows_NT'
+            cmd_with_args.shift.to_s.enclose_in_double_quotes
+          else
+            cmd_with_args.shift.to_s.enclose_in_single_quotes
+          end
         end
       end
     end

--- a/lib/stdlib_exts/string.rb
+++ b/lib/stdlib_exts/string.rb
@@ -8,5 +8,10 @@ class String
     return "''" if nil? || empty?
     split(/'/, -1).map{|e| "'#{e}'"}.join("\\'")
   end
-  
+
+  def enclose_in_double_quotes
+    return '""' if nil? || empty?
+    split(/"/, -1).map{|e| "\"#{e}\""}.join("\\\"")
+  end
+
 end


### PR DESCRIPTION
I hit two stumbling blocks when trying to use mercurial-ruby on windows:
- popen4 ultimately calls fork, which is unsupported
- shell tries to wrap command arguments in single quotes, which the windows shell hates

I've verified that neither change regresses existing tests (open3 codepath passes everything, double-quote codepath passes everything except tests to ensure that we're using single quotes to wrap)
